### PR TITLE
fix: change the Cloud URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The configuration options are described in the [**Inputs**](#inputs) section, an
 
 ### Testkube Cloud
 
-To use this GitHub Action for the [**Testkube Cloud**](https://cloud.testkube.io), you need to [**create API token**](https://docs.testkube.io/testkube-cloud/organization-management#api-tokens).
+To use this GitHub Action for the [**Testkube Cloud**](https://app.testkube.io), you need to [**create API token**](https://docs.testkube.io/testkube-cloud/organization-management#api-tokens).
 
 Then, pass the `organization` and `environment` IDs for the test, along with the `token` and other parameters specific for your use case:
 


### PR DESCRIPTION
## Changes

- Migrate `cloud.testkube.io` to `app.testkube.io`

## Fixes

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
